### PR TITLE
Adding support for undo/redo commands

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -16,8 +16,8 @@ By : `Team F12-B2`  &nbsp;&nbsp;&nbsp;&nbsp; Since: `Mar 2017`  &nbsp;&nbsp;&nbs
    > Having any Java 8 version is not enough. <br>
    > This app will not work with earlier versions of Java 8.
 
-1. Download the latest `addressbook.jar` from the [releases](../../../releases) tab.
-2. Copy the file to the folder you want to use as the home folder for your Address Book.
+1. Download the latest `ToDoApp.jar` from the [releases](../../../releases) tab.
+2. Copy the file to the folder you want to use as the home folder for your ToDoApp.
 3. Double-click the file to start the app. The GUI should appear in a few seconds.
    > <img src="images/Ui.png" width="600">
 
@@ -132,7 +132,7 @@ Examples:
 * `schedule 2 07/07/17`<br>
 Adds a deadline of 7th July 2017 to task at index 2.
 
-### 2.7. Find specific tasks
+### 2.8. Find specific tasks
 
 Retrieve tasks based on various conditions.<br>
 Format: `find [d/DEADLINE] [p/PRIORITY] [t/TAG]`
@@ -149,16 +149,31 @@ Retrieve all tasks with the tag CS2103.
 Exits the program.<br>
 Format: `exit`
 
-### 2.10. Saving the data
+### 2.10. Undo a recent command: `undo`
 
-Address book data are saved in the hard disk automatically after any command that changes the data.<br>
+Undo the most recent command<br>
+Format: `undo`
+
+> * Can undo commands `add`, `delete`, `edit`
+
+### 2.11. Redo a recent command: `undo`
+
+Redo the most recent command<br>
+Format: `redo`
+
+> * Can redo commands that were most recently undone
+> * Inputting a new undo-able command clears the redo state history
+
+### 2.12. Saving the data
+
+ToDoApp data are saved in the hard disk automatically after any command that changes the data.<br>
 There is no need to save manually.
 
 ## 3. FAQ
 
 **Q**: How do I transfer my data to another Computer?<br>
 **A**: Install the app in the other computer and overwrite the empty data file it creates with
-       the file that contains the data of your previous Address Book folder.
+       the file that contains the data of your previous ToDoApp folder.
 
 ## 4. Command Summary
 

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -36,11 +36,12 @@ public class LogicManager extends ComponentManager implements Logic {
         Command command = parser.parseCommand(commandText);
         command.setData(model);
         // Evaluate inverse of command
-        Command inverseCommand = parser.parseInverseCommand(commandText);
+        Command inverseCommand = parser.parseInverseCommand(commandText, model);
         // Check if inverse of command exist
         if (inverseCommand != null) {
             // Store the command
             StateCommandPair stateCommandPair = new StateCommandPair(command, inverseCommand);
+            stateCommandPair.setModel(model);
             stateManager.onNewCommand(stateCommandPair);
         }
         // Execute the command

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -37,9 +37,12 @@ public class LogicManager extends ComponentManager implements Logic {
         command.setData(model);
         // Evaluate inverse of command
         Command inverseCommand = parser.parseInverseCommand(commandText);
-        // Store the command
-        StateCommandPair stateCommandPair = new StateCommandPair(command, inverseCommand);
-        stateManager.onNewCommand(stateCommandPair);
+        // Check if inverse of command exist
+        if (inverseCommand != null) {
+            // Store the command
+            StateCommandPair stateCommandPair = new StateCommandPair(command, inverseCommand);
+            stateManager.onNewCommand(stateCommandPair);
+        }
         // Execute the command
         return command.execute();
     }

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -10,8 +10,8 @@ import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.Parser;
 import seedu.address.model.Model;
-import seedu.address.model.StateManager;
 import seedu.address.model.StateCommandPair;
+import seedu.address.model.StateManager;
 import seedu.address.model.person.ReadOnlyTask;
 import seedu.address.storage.Storage;
 

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -10,6 +10,8 @@ import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.Parser;
 import seedu.address.model.Model;
+import seedu.address.model.StateManager;
+import seedu.address.model.StateCommandPair;
 import seedu.address.model.person.ReadOnlyTask;
 import seedu.address.storage.Storage;
 
@@ -21,6 +23,7 @@ public class LogicManager extends ComponentManager implements Logic {
 
     private final Model model;
     private final Parser parser;
+    private final StateManager stateManager = StateManager.getInstance();
 
     public LogicManager(Model model, Storage storage) {
         this.model = model;
@@ -32,6 +35,12 @@ public class LogicManager extends ComponentManager implements Logic {
         logger.info("----------------[USER COMMAND][" + commandText + "]");
         Command command = parser.parseCommand(commandText);
         command.setData(model);
+        // Evaluate inverse of command
+        Command inverseCommand = parser.parseInverseCommand(commandText);
+        // Store the command
+        StateCommandPair stateCommandPair = new StateCommandPair(command, inverseCommand);
+        stateManager.onNewCommand(stateCommandPair);
+        // Execute the command
         return command.execute();
     }
 

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -31,6 +31,7 @@ public class AddCommand extends Command {
     public static final String MESSAGE_DUPLICATE_TASK = "This task already exists in the ToDoApp";
 
     private final Task toAdd;
+    private final int idx; // Optional adding of index
 
     /**
      * Creates an AddCommand using raw values.
@@ -38,7 +39,7 @@ public class AddCommand extends Command {
      * @throws IllegalValueException if any of the raw values are invalid
      */
     public AddCommand(String name, String start, String deadline,
-                        Integer priority, Set<String> tags, String notes)
+                        Integer priority, Set<String> tags, String notes, int idx)
             throws IllegalValueException {
         final Set<Tag> tagSet = new HashSet<>();
         for (String tagName : tags) {
@@ -52,13 +53,18 @@ public class AddCommand extends Command {
                 new UniqueTagList(tagSet),
                 new Notes(notes)
         );
+        this.idx = idx;
     }
 
     @Override
     public CommandResult execute() throws CommandException {
         assert model != null;
         try {
-            model.addTask(toAdd);
+            if (this.idx >= 0) {
+                model.addTask(toAdd, idx);
+            } else {
+                model.addTask(toAdd);
+            }
             return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
         } catch (UniqueTaskList.DuplicateTaskException e) {
             throw new CommandException(MESSAGE_DUPLICATE_TASK);

--- a/src/main/java/seedu/address/logic/commands/RedoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RedoCommand.java
@@ -7,7 +7,7 @@ import seedu.address.model.StateManager;
  * Redo most recent command
  */
 public class RedoCommand extends Command {
-    public static final String COMMAND_WORD = "Redo";
+    public static final String COMMAND_WORD = "redo";
     public static final String MESSAGE_SUCCESS = "Redid most recent command";
     private final StateManager stateManager = StateManager.getInstance();
 

--- a/src/main/java/seedu/address/logic/commands/RedoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RedoCommand.java
@@ -1,0 +1,19 @@
+package seedu.address.logic.commands;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.StateManager;
+
+/**
+ * Redo most recent command
+ */
+public class RedoCommand extends Command {
+    public static final String COMMAND_WORD = "Redo";
+    public static final String MESSAGE_SUCCESS = "Redid most recent command";
+    private final StateManager stateManager = StateManager.getInstance();
+
+    @Override
+    public CommandResult execute() throws CommandException {
+        stateManager.redo();
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/RedoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RedoCommand.java
@@ -9,11 +9,17 @@ import seedu.address.model.StateManager;
 public class RedoCommand extends Command {
     public static final String COMMAND_WORD = "redo";
     public static final String MESSAGE_SUCCESS = "Redid most recent command";
+    public static final String MESSAGE_FAIL = "No command to redo";
+    
     private final StateManager stateManager = StateManager.getInstance();
 
     @Override
     public CommandResult execute() throws CommandException {
-        stateManager.redo();
-        return new CommandResult(MESSAGE_SUCCESS);
+        if (stateManager.redoStackHasCommands()) {
+            stateManager.redo();
+            return new CommandResult(MESSAGE_SUCCESS);
+        } else {
+            return new CommandResult(MESSAGE_FAIL);
+        }
     }
 }

--- a/src/main/java/seedu/address/logic/commands/RedoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RedoCommand.java
@@ -10,7 +10,7 @@ public class RedoCommand extends Command {
     public static final String COMMAND_WORD = "redo";
     public static final String MESSAGE_SUCCESS = "Redid most recent command";
     public static final String MESSAGE_FAIL = "No command to redo";
-    
+
     private final StateManager stateManager = StateManager.getInstance();
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -10,7 +10,7 @@ public class UndoCommand extends Command {
     public static final String COMMAND_WORD = "undo";
     public static final String MESSAGE_SUCCESS = "Undid most recent command";
     public static final String MESSAGE_FAIL = "No command to undo";
-    
+
     private final StateManager stateManager = StateManager.getInstance();
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -9,11 +9,17 @@ import seedu.address.model.StateManager;
 public class UndoCommand extends Command {
     public static final String COMMAND_WORD = "undo";
     public static final String MESSAGE_SUCCESS = "Undid most recent command";
+    public static final String MESSAGE_FAIL = "No command to undo";
+    
     private final StateManager stateManager = StateManager.getInstance();
 
     @Override
     public CommandResult execute() throws CommandException {
-        stateManager.undo();
-        return new CommandResult(MESSAGE_SUCCESS);
+        if (stateManager.undoStackHasCommands()) {
+            stateManager.undo();
+            return new CommandResult(MESSAGE_SUCCESS);
+        } else {
+            return new CommandResult(MESSAGE_FAIL);
+        }
     }
 }

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -1,14 +1,19 @@
 package seedu.address.logic.commands;
 
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.StateManager;
+
 /**
  * Undo most recent command
  */
 public class UndoCommand extends Command {
     public static final String COMMAND_WORD = "undo";
     public static final String MESSAGE_SUCCESS = "Undid most recent command";
+    private final StateManager stateManager = StateManager.getInstance();
 
     @Override
-    public CommandResult execute() {
+    public CommandResult execute() throws CommandException {
+        stateManager.undo();
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -1,0 +1,14 @@
+package seedu.address.logic.commands;
+
+/**
+ * Undo most recent command
+ */
+public class UndoCommand extends Command {
+    public static final String COMMAND_WORD = "undo";
+    public static final String MESSAGE_SUCCESS = "Undid most recent command";
+
+    @Override
+    public CommandResult execute() {
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -22,7 +22,7 @@ public class AddCommandParser {
      * Parses the given {@code String} of arguments in the context of the AddCommand
      * and returns an AddCommand object for execution.
      */
-    public Command parse(String args) {
+    public Command parse(String args, int idx) {
         ArgumentTokenizer argsTokenizer =
                 new ArgumentTokenizer(PREFIX_START, PREFIX_DEADLINE, PREFIX_PRIORITY, PREFIX_TAG, PREFIX_NOTES);
         argsTokenizer.tokenize(args);
@@ -35,7 +35,7 @@ public class AddCommandParser {
 
         try {
             return new AddCommand(name, start, deadline, priority,
-                    ParserUtil.toSet(argsTokenizer.getAllValues(PREFIX_TAG)), notes
+                    ParserUtil.toSet(argsTokenizer.getAllValues(PREFIX_TAG)), notes, idx
             );
         } catch (NoSuchElementException nsee) {
             return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));

--- a/src/main/java/seedu/address/logic/parser/NattyParser.java
+++ b/src/main/java/seedu/address/logic/parser/NattyParser.java
@@ -1,3 +1,4 @@
+//@@author A0114395E
 package seedu.address.logic.parser;
 
 import java.util.List;

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -68,7 +68,7 @@ public class Parser {
         switch (commandWord) {
 
         case AddCommand.COMMAND_WORD:
-            return new AddCommandParser().parse(arguments);
+            return new AddCommandParser().parse(arguments, -1);
 
         case EditCommand.COMMAND_WORD:
             return new EditCommandParser().parse(arguments);
@@ -147,7 +147,8 @@ public class Parser {
             index = ParserUtil.parseIndex(arguments);
             // Get data of command to be deleted
             ReadOnlyTask taskToDelete = lastShownList.get(index.get() - 1);
-            return new AddCommandParser().parse(ParserUtil.getTaskArgs(taskToDelete));
+            return new AddCommandParser().parse(ParserUtil.getTaskArgs(taskToDelete), index.get() - 1);
+
         default:
             return null;
         }

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -134,19 +134,18 @@ public class Parser {
             Optional<Integer> index = ParserUtil.parseIndex(arguments);
             // Get data of command to be deleted
             ReadOnlyTask taskToDelete = lastShownList.get(index.get() - 1);
-            return new AddCommandParser().parse(getAddArgs(taskToDelete));
+            return new AddCommandParser().parse(getTaskArgs(taskToDelete));
         default:
             return null;
         }
     }
 
-    //@@author A0114395E
     /*
-     * Helper method to parse a ReadOnlyTask into an command-line Add statement to be stored.
+     * Helper method to parse a ReadOnlyTask into an command-line statement to be stored.
      * @param ReadOnlyTask
-     * @returns String consisting of how a user would have typed the 'Add' command
+     * @returns String consisting of how a user would have typed the original command
      */
-    private static String getAddArgs(ReadOnlyTask task) {
+    private static String getTaskArgs(ReadOnlyTask task) {
         // Build arguments
         final StringBuilder builder = new StringBuilder();
         builder.append(task.getName());
@@ -178,7 +177,6 @@ public class Parser {
             // Remove square brackets for tags
             builder.append(tagBuilder.toString().replaceAll("\\[", "").replaceAll("\\]",""));
         }
-        System.out.println(builder.toString());
         return builder.toString();
     }
 }

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -129,8 +130,13 @@ public class Parser {
             return null;
 
         case DeleteCommand.COMMAND_WORD:
-            return null;
-
+            Optional<Integer> index = ParserUtil.parseIndex(arguments);
+            // Get data of command to be deleted
+            ReadOnlyTask taskToDelete = lastShownList.get(index.get() - 1);
+            System.out.println("Got task to delete");
+            System.out.println(taskToDelete.getAsText());
+            return null;//new AddCommandParser().parse("some argument..");
+        
         default:
             return null;
         }

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -140,56 +140,16 @@ public class Parser {
             editBuilder.append(" ");
             editBuilder.append(index.get().toString());
             editBuilder.append(" ");
-            editBuilder.append(getTaskArgs(taskToEdit));
+            editBuilder.append(ParserUtil.getTaskArgs(taskToEdit));
             return new EditCommandParser().parse(editBuilder.toString());
 
         case DeleteCommand.COMMAND_WORD:
             index = ParserUtil.parseIndex(arguments);
             // Get data of command to be deleted
             ReadOnlyTask taskToDelete = lastShownList.get(index.get() - 1);
-            return new AddCommandParser().parse(getTaskArgs(taskToDelete));
+            return new AddCommandParser().parse(ParserUtil.getTaskArgs(taskToDelete));
         default:
             return null;
         }
-    }
-
-    /*
-     * Helper method to parse a ReadOnlyTask into an command-line statement to be stored.
-     * @param ReadOnlyTask
-     * @returns String consisting of how a user would have typed the original command
-     */
-    private static String getTaskArgs(ReadOnlyTask task) {
-        // Build arguments
-        final StringBuilder builder = new StringBuilder();
-        builder.append(task.getName());
-        if (task.getStart().toString().length() > 0) {
-            builder.append(" ");
-            builder.append(CliSyntax.PREFIX_START.getPrefix());
-            builder.append(task.getStart().toString());
-        }
-        if (task.getDeadline().toString().length() > 0) {
-            builder.append(" ");
-            builder.append(CliSyntax.PREFIX_DEADLINE.getPrefix());
-            builder.append(task.getDeadline().toString());
-        }
-        if (task.getPriority().toString().length() > 0) {
-            builder.append(" ");
-            builder.append(CliSyntax.PREFIX_PRIORITY.getPrefix());
-            builder.append(task.getPriority().toString());
-        }
-        if (task.getNotes().toString().length() > 0) {
-            builder.append(" ");
-            builder.append(CliSyntax.PREFIX_NOTES.getPrefix());
-            builder.append(task.getNotes().toString());
-        }
-        if (task.getTags().asObservableList().size() > 0) {
-            builder.append(" ");
-            builder.append(CliSyntax.PREFIX_TAG.getPrefix());
-            final StringBuilder tagBuilder = new StringBuilder();
-            task.getTags().forEach(tagBuilder::append);
-            // Remove square brackets for tags
-            builder.append(tagBuilder.toString().replaceAll("\\[", "").replaceAll("\\]", ""));
-        }
-        return builder.toString();
     }
 }

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -92,10 +92,10 @@ public class Parser {
             return new HelpCommand();
         
         case UndoCommand.COMMAND_WORD:
-            return new UndoCommand();        
+            return new UndoCommand();       
         
         case RedoCommand.COMMAND_WORD:
-            return new RedoCommand();            
+            return new RedoCommand();
             
         default:
             return new IncorrectCommand(MESSAGE_UNKNOWN_COMMAND);
@@ -116,11 +116,12 @@ public class Parser {
         }
 
         UnmodifiableObservableList<ReadOnlyTask> lastShownList = model.getFilteredTaskList();
+        
         final String commandWord = matcher.group("commandWord");
         final String arguments = matcher.group("arguments");
 
         switch (commandWord) {
-            
+
         case AddCommand.COMMAND_WORD:
             return new DeleteCommand(lastShownList.size() + 1);
 

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -91,4 +91,13 @@ public class Parser {
         }
     }
 
+    /**
+     * Parses user input into its inverse command for undo command.
+     *
+     * @param userInput full user input string
+     * @return the inverse of the command based on the user input
+     */
+    public Command parseInverseCommand(String userInput) {
+        return this.parseCommand(userInput); // Stub
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -23,7 +23,6 @@ import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.model.Model;
 import seedu.address.model.person.ReadOnlyTask;
-import seedu.address.model.tag.UniqueTagList;
 
 /**
  * Parses user input.
@@ -104,7 +103,7 @@ public class Parser {
         }
     }
 
-    //@@author A0114395E    
+    //@@author A0114395E
     /**
      * Parses user input into its inverse command for undo command.
      * Only supports inverse of Add, Delete, Edit.
@@ -140,7 +139,7 @@ public class Parser {
             return null;
         }
     }
-    
+
     //@@author A0114395E
     /*
      * Helper method to parse a ReadOnlyTask into an command-line Add statement to be stored.
@@ -171,7 +170,7 @@ public class Parser {
             builder.append(CliSyntax.PREFIX_NOTES.getPrefix());
             builder.append(task.getNotes().toString());
         }
-        if (task.getTags().asObservableList().size() > 0){
+        if (task.getTags().asObservableList().size() > 0) {
             builder.append(" ");
             builder.append(CliSyntax.PREFIX_TAG.getPrefix());
             task.getTags().forEach(builder::append);

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -17,6 +17,8 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.IncorrectCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.SelectCommand;
+import seedu.address.logic.commands.UndoCommand;
+import seedu.address.logic.commands.RedoCommand;
 
 /**
  * Parses user input.
@@ -85,7 +87,13 @@ public class Parser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
-
+        
+        case UndoCommand.COMMAND_WORD:
+            return new UndoCommand();        
+        
+        case RedoCommand.COMMAND_WORD:
+            return new RedoCommand();            
+            
         default:
             return new IncorrectCommand(MESSAGE_UNKNOWN_COMMAND);
         }

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -101,11 +101,32 @@ public class Parser {
 
     /**
      * Parses user input into its inverse command for undo command.
+     * Only supports inverse of Add, Delete, Edit.
      *
      * @param userInput full user input string
      * @return the inverse of the command based on the user input
      */
     public Command parseInverseCommand(String userInput) {
-        return this.parseCommand(userInput); // Stub
+        final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
+        if (!matcher.matches()) {
+            return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+        }
+
+        final String commandWord = matcher.group("commandWord");
+        final String arguments = matcher.group("arguments");
+        switch (commandWord) {
+
+        case AddCommand.COMMAND_WORD:
+            return new IncorrectCommand(MESSAGE_UNKNOWN_COMMAND);
+
+        case EditCommand.COMMAND_WORD:
+            return new IncorrectCommand(MESSAGE_UNKNOWN_COMMAND);
+
+        case DeleteCommand.COMMAND_WORD:
+            return new IncorrectCommand(MESSAGE_UNKNOWN_COMMAND);
+        
+        default:
+            return null;
+        }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -23,6 +23,7 @@ import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.model.Model;
 import seedu.address.model.person.ReadOnlyTask;
+import seedu.address.model.tag.UniqueTagList;
 
 /**
  * Parses user input.
@@ -103,6 +104,7 @@ public class Parser {
         }
     }
 
+    //@@author A0114395E    
     /**
      * Parses user input into its inverse command for undo command.
      * Only supports inverse of Add, Delete, Edit.
@@ -133,12 +135,47 @@ public class Parser {
             Optional<Integer> index = ParserUtil.parseIndex(arguments);
             // Get data of command to be deleted
             ReadOnlyTask taskToDelete = lastShownList.get(index.get() - 1);
-            System.out.println("Got task to delete");
-            System.out.println(taskToDelete.getAsText());
-            return null;//new AddCommandParser().parse("some argument..");
-        
+            return new AddCommandParser().parse(getAddArgs(taskToDelete));
         default:
             return null;
         }
+    }
+    
+    //@@author A0114395E
+    /*
+     * Helper method to parse a ReadOnlyTask into an command-line Add statement to be stored.
+     * @param ReadOnlyTask
+     * @returns String consisting of how a user would have typed the 'Add' command
+     */
+    private static String getAddArgs(ReadOnlyTask task) {
+        // Build arguments
+        final StringBuilder builder = new StringBuilder();
+        builder.append(task.getName());
+        if (task.getStart().toString().length() > 0) {
+            builder.append(" ");
+            builder.append(CliSyntax.PREFIX_START.getPrefix());
+            builder.append(task.getStart().toString());
+        }
+        if (task.getDeadline().toString().length() > 0) {
+            builder.append(" ");
+            builder.append(CliSyntax.PREFIX_DEADLINE.getPrefix());
+            builder.append(task.getDeadline().toString());
+        }
+        if (task.getPriority().toString().length() > 0) {
+            builder.append(" ");
+            builder.append(CliSyntax.PREFIX_PRIORITY.getPrefix());
+            builder.append(task.getPriority().toString());
+        }
+        if (task.getNotes().toString().length() > 0) {
+            builder.append(" ");
+            builder.append(CliSyntax.PREFIX_NOTES.getPrefix());
+            builder.append(task.getNotes().toString());
+        }
+        if (task.getTags().asObservableList().size() > 0){
+            builder.append(" ");
+            builder.append(CliSyntax.PREFIX_TAG.getPrefix());
+            task.getTags().forEach(builder::append);
+        }
+        return builder.toString();
     }
 }

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -6,6 +6,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import seedu.address.commons.core.UnmodifiableObservableList;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
@@ -18,6 +19,8 @@ import seedu.address.logic.commands.IncorrectCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.UndoCommand;
+import seedu.address.model.Model;
+import seedu.address.model.person.ReadOnlyTask;
 import seedu.address.logic.commands.RedoCommand;
 
 /**
@@ -106,24 +109,26 @@ public class Parser {
      * @param userInput full user input string
      * @return the inverse of the command based on the user input
      */
-    public Command parseInverseCommand(String userInput) {
+    public Command parseInverseCommand(String userInput, Model model) {
         final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
         if (!matcher.matches()) {
             return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
         }
 
+        UnmodifiableObservableList<ReadOnlyTask> lastShownList = model.getFilteredTaskList();
         final String commandWord = matcher.group("commandWord");
         final String arguments = matcher.group("arguments");
-        switch (commandWord) {
 
+        switch (commandWord) {
+            
         case AddCommand.COMMAND_WORD:
-            return new IncorrectCommand(MESSAGE_UNKNOWN_COMMAND);
+            return new DeleteCommand(lastShownList.size() + 1);
 
         case EditCommand.COMMAND_WORD:
-            return new IncorrectCommand(MESSAGE_UNKNOWN_COMMAND);
+            return null;
 
         case DeleteCommand.COMMAND_WORD:
-            return new IncorrectCommand(MESSAGE_UNKNOWN_COMMAND);
+            return null;
         
         default:
             return null;

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -17,11 +17,11 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.IncorrectCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.model.Model;
 import seedu.address.model.person.ReadOnlyTask;
-import seedu.address.logic.commands.RedoCommand;
 
 /**
  * Parses user input.
@@ -90,13 +90,13 @@ public class Parser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
-        
+
         case UndoCommand.COMMAND_WORD:
-            return new UndoCommand();       
-        
+            return new UndoCommand();
+
         case RedoCommand.COMMAND_WORD:
             return new RedoCommand();
-            
+
         default:
             return new IncorrectCommand(MESSAGE_UNKNOWN_COMMAND);
         }
@@ -116,7 +116,7 @@ public class Parser {
         }
 
         UnmodifiableObservableList<ReadOnlyTask> lastShownList = model.getFilteredTaskList();
-        
+
         final String commandWord = matcher.group("commandWord");
         final String arguments = matcher.group("arguments");
 
@@ -130,7 +130,7 @@ public class Parser {
 
         case DeleteCommand.COMMAND_WORD:
             return null;
-        
+
         default:
             return null;
         }

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -173,8 +173,12 @@ public class Parser {
         if (task.getTags().asObservableList().size() > 0) {
             builder.append(" ");
             builder.append(CliSyntax.PREFIX_TAG.getPrefix());
-            task.getTags().forEach(builder::append);
+            final StringBuilder tagBuilder = new StringBuilder();
+            task.getTags().forEach(tagBuilder::append);
+            // Remove square brackets for tags
+            builder.append(tagBuilder.toString().replaceAll("\\[", "").replaceAll("\\]",""));
         }
+        System.out.println(builder.toString());
         return builder.toString();
     }
 }

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -27,6 +27,7 @@ public class Parser {
      * Used for initial separation of command word and args.
      */
     private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
+    //@@author A0114395E
     private static Parser instance = null;
 
     // Exists only to defeat instantiation.
@@ -40,6 +41,7 @@ public class Parser {
         }
         return instance;
     }
+    //@@author
 
     /**
      * Parses user input into command for execution.

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.model.person.Name;
+import seedu.address.model.person.ReadOnlyTask;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.tag.UniqueTagList;
 
@@ -81,5 +82,46 @@ public class ParserUtil {
             tagSet.add(new Tag(tagName));
         }
         return new UniqueTagList(tagSet);
+    }
+    
+    //@@author A0114395E
+    /*
+     * Helper method to parse a ReadOnlyTask into an command-line statement to be stored.
+     * @param ReadOnlyTask
+     * @returns String consisting of how a user would have typed the original command
+     */
+    public static String getTaskArgs(ReadOnlyTask task) {
+        // Build arguments
+        final StringBuilder builder = new StringBuilder();
+        builder.append(task.getName());
+        if (task.getStart().toString().length() > 0) {
+            builder.append(" ");
+            builder.append(CliSyntax.PREFIX_START.getPrefix());
+            builder.append(task.getStart().toString());
+        }
+        if (task.getDeadline().toString().length() > 0) {
+            builder.append(" ");
+            builder.append(CliSyntax.PREFIX_DEADLINE.getPrefix());
+            builder.append(task.getDeadline().toString());
+        }
+        if (task.getPriority().toString().length() > 0) {
+            builder.append(" ");
+            builder.append(CliSyntax.PREFIX_PRIORITY.getPrefix());
+            builder.append(task.getPriority().toString());
+        }
+        if (task.getNotes().toString().length() > 0) {
+            builder.append(" ");
+            builder.append(CliSyntax.PREFIX_NOTES.getPrefix());
+            builder.append(task.getNotes().toString());
+        }
+        if (task.getTags().asObservableList().size() > 0) {
+            builder.append(" ");
+            builder.append(CliSyntax.PREFIX_TAG.getPrefix());
+            final StringBuilder tagBuilder = new StringBuilder();
+            task.getTags().forEach(tagBuilder::append);
+            // Remove square brackets for tags
+            builder.append(tagBuilder.toString().replaceAll("\\[", "").replaceAll("\\]", ""));
+        }
+        return builder.toString();
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -83,7 +83,7 @@ public class ParserUtil {
         }
         return new UniqueTagList(tagSet);
     }
-    
+
     //@@author A0114395E
     /*
      * Helper method to parse a ReadOnlyTask into an command-line statement to be stored.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -23,6 +23,9 @@ public interface Model {
     /** Adds the given task */
     void addTask(Task task) throws UniqueTaskList.DuplicateTaskException;
 
+    /** Adds the given task at a specified index */
+    void addTask(Task task, int idx) throws UniqueTaskList.DuplicateTaskException;
+
     /**
      * Updates the person located at {@code filteredPersonListIndex} with {@code editedPerson}.
      *

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -23,9 +23,11 @@ public interface Model {
     /** Adds the given task */
     void addTask(Task task) throws UniqueTaskList.DuplicateTaskException;
 
+    //@@author A0114395E
     /** Adds the given task at a specified index */
     void addTask(Task task, int idx) throws UniqueTaskList.DuplicateTaskException;
-
+    //@@author
+    
     /**
      * Updates the person located at {@code filteredPersonListIndex} with {@code editedPerson}.
      *

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -27,7 +27,7 @@ public interface Model {
     /** Adds the given task at a specified index */
     void addTask(Task task, int idx) throws UniqueTaskList.DuplicateTaskException;
     //@@author
-    
+
     /**
      * Updates the person located at {@code filteredPersonListIndex} with {@code editedPerson}.
      *

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -71,6 +71,7 @@ public class ModelManager extends ComponentManager implements Model {
         indicateToDoAppChanged();
     }
 
+    //@@author A0114395E
     @Override
     public synchronized void addTask(Task task, int idx) throws UniqueTaskList.DuplicateTaskException {
         toDoApp.addTask(task, idx);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -78,6 +78,7 @@ public class ModelManager extends ComponentManager implements Model {
         updateFilteredListToShowAll();
         indicateToDoAppChanged();
     }
+    //@@author
 
     @Override
     public void updateTask(int filteredTaskListIndex, ReadOnlyTask editedTask)

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -70,7 +70,7 @@ public class ModelManager extends ComponentManager implements Model {
         updateFilteredListToShowAll();
         indicateToDoAppChanged();
     }
-    
+
     @Override
     public synchronized void addTask(Task task, int idx) throws UniqueTaskList.DuplicateTaskException {
         toDoApp.addTask(task, idx);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -70,6 +70,13 @@ public class ModelManager extends ComponentManager implements Model {
         updateFilteredListToShowAll();
         indicateToDoAppChanged();
     }
+    
+    @Override
+    public synchronized void addTask(Task task, int idx) throws UniqueTaskList.DuplicateTaskException {
+        toDoApp.addTask(task, idx);
+        updateFilteredListToShowAll();
+        indicateToDoAppChanged();
+    }
 
     @Override
     public void updateTask(int filteredTaskListIndex, ReadOnlyTask editedTask)

--- a/src/main/java/seedu/address/model/StateCommand.java
+++ b/src/main/java/seedu/address/model/StateCommand.java
@@ -1,0 +1,19 @@
+package seedu.address.model;
+
+import seedu.address.logic.commands.*;
+
+/**
+ * Class to store an action, and it's inverse
+ */
+public class StateCommand {
+    private String executeCommand;
+    private String undoCommand;
+    
+    public void execute() {
+        System.out.println(executeCommand);
+    }
+    
+    public void executeInvese() {
+        System.out.println(undoCommand);
+    }
+}

--- a/src/main/java/seedu/address/model/StateCommandPair.java
+++ b/src/main/java/seedu/address/model/StateCommandPair.java
@@ -11,28 +11,28 @@ public class StateCommandPair {
     private Command executeCommand;
     private Command undoCommand;
     private Model model;
-    
+
     public void setModel(Model model) {
         this.model = model;
     }
-    
+
     public StateCommandPair(Command cmd, Command inverseCmd) {
         this.executeCommand = cmd;
         this.undoCommand = inverseCmd;
     }
-    
+
     /**
      * Executes the command previously entered (for redo)
-     * @throws CommandException 
+     * @throws CommandException
      */
     public void executeCommand() throws CommandException {
         this.executeCommand.setData(model);
         this.executeCommand.execute();
     }
-    
+
     /**
      * Executes the inverse of the command previously entered (for undo)
-     * @throws CommandException 
+     * @throws CommandException
      */
     public void executeInverseCommand() throws CommandException {
         System.out.println("State Pair - executing undo");

--- a/src/main/java/seedu/address/model/StateCommandPair.java
+++ b/src/main/java/seedu/address/model/StateCommandPair.java
@@ -7,14 +7,34 @@ import seedu.address.logic.commands.*;
  * Class to store an action, and it's inverse
  */
 public class StateCommandPair {
-    private String executeCommand;
-    private String undoCommand;
+    private Command executeCommand;
+    private Command undoCommand;
     
+    public StateCommandPair(Command cmd) {
+        this.executeCommand = cmd;
+        this.undoCommand = this.evaluateInverse(cmd);
+    }
+    
+    /**
+     * Executes the command previously entered (for redo)
+     */
     public void execute() {
         System.out.println(executeCommand);
     }
     
+    /**
+     * Executes the inverse of the command previously entered (for undo)
+     */
     public void executeInvese() {
         System.out.println(undoCommand);
+    }
+    
+    /**
+     * 
+     * @param Command
+     * @return an Inverse action of the Command
+     */
+    private Command evaluateInverse(Command cmd) {
+        return cmd;// stub
     }
 }

--- a/src/main/java/seedu/address/model/StateCommandPair.java
+++ b/src/main/java/seedu/address/model/StateCommandPair.java
@@ -1,3 +1,4 @@
+//@@author A0114395E
 package seedu.address.model;
 
 import seedu.address.logic.commands.*;

--- a/src/main/java/seedu/address/model/StateCommandPair.java
+++ b/src/main/java/seedu/address/model/StateCommandPair.java
@@ -2,6 +2,7 @@
 package seedu.address.model;
 
 import seedu.address.logic.commands.*;
+import seedu.address.logic.commands.exceptions.CommandException;
 
 /**
  * Class to store an action, and it's inverse
@@ -10,31 +11,24 @@ public class StateCommandPair {
     private Command executeCommand;
     private Command undoCommand;
     
-    public StateCommandPair(Command cmd) {
+    public StateCommandPair(Command cmd, Command inverseCmd) {
         this.executeCommand = cmd;
-        this.undoCommand = this.evaluateInverse(cmd);
+        this.undoCommand = inverseCmd;
     }
     
     /**
      * Executes the command previously entered (for redo)
+     * @throws CommandException 
      */
-    public void execute() {
-        System.out.println(executeCommand);
+    public void execute() throws CommandException {
+        this.executeCommand.execute();
     }
     
     /**
      * Executes the inverse of the command previously entered (for undo)
+     * @throws CommandException 
      */
-    public void executeInvese() {
-        System.out.println(undoCommand);
-    }
-    
-    /**
-     * 
-     * @param Command
-     * @return an Inverse action of the Command
-     */
-    private Command evaluateInverse(Command cmd) {
-        return cmd;// stub
+    public void executeInvese() throws CommandException {
+        this.undoCommand.execute();
     }
 }

--- a/src/main/java/seedu/address/model/StateCommandPair.java
+++ b/src/main/java/seedu/address/model/StateCommandPair.java
@@ -5,7 +5,7 @@ import seedu.address.logic.commands.*;
 /**
  * Class to store an action, and it's inverse
  */
-public class StateCommand {
+public class StateCommandPair {
     private String executeCommand;
     private String undoCommand;
     

--- a/src/main/java/seedu/address/model/StateCommandPair.java
+++ b/src/main/java/seedu/address/model/StateCommandPair.java
@@ -1,7 +1,7 @@
 //@@author A0114395E
 package seedu.address.model;
 
-import seedu.address.logic.commands.*;
+import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.exceptions.CommandException;
 
 /**

--- a/src/main/java/seedu/address/model/StateCommandPair.java
+++ b/src/main/java/seedu/address/model/StateCommandPair.java
@@ -20,7 +20,7 @@ public class StateCommandPair {
      * Executes the command previously entered (for redo)
      * @throws CommandException 
      */
-    public void execute() throws CommandException {
+    public void executeCommand() throws CommandException {
         this.executeCommand.execute();
     }
     
@@ -28,7 +28,7 @@ public class StateCommandPair {
      * Executes the inverse of the command previously entered (for undo)
      * @throws CommandException 
      */
-    public void executeInvese() throws CommandException {
+    public void executeInverseCommand() throws CommandException {
         this.undoCommand.execute();
     }
 }

--- a/src/main/java/seedu/address/model/StateCommandPair.java
+++ b/src/main/java/seedu/address/model/StateCommandPair.java
@@ -10,6 +10,11 @@ import seedu.address.logic.commands.exceptions.CommandException;
 public class StateCommandPair {
     private Command executeCommand;
     private Command undoCommand;
+    private Model model;
+    
+    public void setModel(Model model) {
+        this.model = model;
+    }
     
     public StateCommandPair(Command cmd, Command inverseCmd) {
         this.executeCommand = cmd;
@@ -21,6 +26,7 @@ public class StateCommandPair {
      * @throws CommandException 
      */
     public void executeCommand() throws CommandException {
+        this.executeCommand.setData(model);
         this.executeCommand.execute();
     }
     
@@ -29,6 +35,8 @@ public class StateCommandPair {
      * @throws CommandException 
      */
     public void executeInverseCommand() throws CommandException {
+        System.out.println("State Pair - executing undo");
+        this.undoCommand.setData(model);
         this.undoCommand.execute();
     }
 }

--- a/src/main/java/seedu/address/model/StateManager.java
+++ b/src/main/java/seedu/address/model/StateManager.java
@@ -27,7 +27,21 @@ public class StateManager {
         }
         return instance;
     }
-    
+
+    /**
+     * Check if stack exist for redo
+     */
+    public boolean redoStackHasCommands(){
+        return !redoStack.isEmpty();
+    }
+
+    /**
+     * Check if stack exist for undo
+     */
+    public boolean undoStackHasCommands(){
+        return !undoStack.isEmpty();
+    }
+
     /**
      * On each new command, add a new command onto the undo stack to track its history and clear the redo history stack
      */

--- a/src/main/java/seedu/address/model/StateManager.java
+++ b/src/main/java/seedu/address/model/StateManager.java
@@ -1,12 +1,20 @@
 package seedu.address.model;
 
+import java.util.Stack;
+
 /**
  * Singleton class to handle Undo/Redo commands
  */
 public class StateManager {
+    
     private static StateManager instance = null;
+    private Stack<String> undoStack;
+    private Stack<String> redoStack;
+    
     // Exists only to defeat instantiation.
     protected StateManager() {
+        undoStack = new Stack<String>();
+        redoStack = new Stack<String>();
     }
     // Returns the singleton instance
     public static StateManager getInstance() {

--- a/src/main/java/seedu/address/model/StateManager.java
+++ b/src/main/java/seedu/address/model/StateManager.java
@@ -33,6 +33,13 @@ public class StateManager {
     }
     
     /**
+     * Clears the redo-stack (Typically when the user enters a new command)
+     */
+    public void clearRedoStack(StateCommandPair newCommandPair){
+        this.redoStack.clear();
+    }
+
+    /**
      * Undo the most recent command, then store that undo command in a redo stack
      */
     public void undo() {

--- a/src/main/java/seedu/address/model/StateManager.java
+++ b/src/main/java/seedu/address/model/StateManager.java
@@ -10,11 +10,11 @@ import seedu.address.model.StateCommandPair;
  * Singleton class to handle Undo/Redo commands
  */
 public class StateManager {
-    
+
     private static StateManager instance = null;
     private Stack<StateCommandPair> undoStack;
     private Stack<StateCommandPair> redoStack;
-    
+
     // Exists only to defeat instantiation.
     protected StateManager() {
         undoStack = new Stack<StateCommandPair>();
@@ -52,7 +52,7 @@ public class StateManager {
 
     /**
      * Undo the most recent command, then store that undo command in a redo stack
-     * @throws CommandException 
+     * @throws CommandException
      */
     public void undo() throws CommandException {
         if (undoStack.isEmpty()) {
@@ -66,10 +66,10 @@ public class StateManager {
             currentCommand.executeInverseCommand();
         }
     }
-    
+
     /**
      * Redo the most recently 'undo' command, then store that redo command in the undo stack
-     * @throws CommandException 
+     * @throws CommandException
      */
     public void redo() throws CommandException {
         if (redoStack.isEmpty()) {

--- a/src/main/java/seedu/address/model/StateManager.java
+++ b/src/main/java/seedu/address/model/StateManager.java
@@ -1,0 +1,18 @@
+package seedu.address.model;
+
+/**
+ * Singleton class to handle Undo/Redo commands
+ */
+public class StateManager {
+    private static StateManager instance = null;
+    // Exists only to defeat instantiation.
+    protected StateManager() {
+    }
+    // Returns the singleton instance
+    public static StateManager getInstance() {
+        if (instance == null) {
+            instance = new StateManager();
+        }
+        return instance;
+    }
+}

--- a/src/main/java/seedu/address/model/StateManager.java
+++ b/src/main/java/seedu/address/model/StateManager.java
@@ -4,7 +4,6 @@ package seedu.address.model;
 import java.util.Stack;
 
 import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.model.StateCommandPair;
 
 /**
  * Singleton class to handle Undo/Redo commands
@@ -31,21 +30,21 @@ public class StateManager {
     /**
      * Check if stack exist for redo
      */
-    public boolean redoStackHasCommands(){
+    public boolean redoStackHasCommands() {
         return !redoStack.isEmpty();
     }
 
     /**
      * Check if stack exist for undo
      */
-    public boolean undoStackHasCommands(){
+    public boolean undoStackHasCommands() {
         return !undoStack.isEmpty();
     }
 
     /**
      * On each new command, add a new command onto the undo stack to track its history and clear the redo history stack
      */
-    public void onNewCommand(StateCommandPair newCommandPair){
+    public void onNewCommand(StateCommandPair newCommandPair) {
         this.undoStack.push(newCommandPair);
         this.redoStack.clear();
     }

--- a/src/main/java/seedu/address/model/StateManager.java
+++ b/src/main/java/seedu/address/model/StateManager.java
@@ -1,3 +1,4 @@
+//@@author A0114395E
 package seedu.address.model;
 
 import java.util.Stack;

--- a/src/main/java/seedu/address/model/StateManager.java
+++ b/src/main/java/seedu/address/model/StateManager.java
@@ -27,16 +27,10 @@ public class StateManager {
     }
     
     /**
-     * On each new command, add a new command onto the undo stack to track its history
+     * On each new command, add a new command onto the undo stack to track its history and clear the redo history stack
      */
-    public void trackCommand(StateCommandPair newCommandPair){
+    public void onNewCommand(StateCommandPair newCommandPair){
         this.undoStack.push(newCommandPair);
-    }
-    
-    /**
-     * Clears the redo-stack (Typically when the user enters a new command)
-     */
-    public void clearRedoStack(StateCommandPair newCommandPair){
         this.redoStack.clear();
     }
 

--- a/src/main/java/seedu/address/model/StateManager.java
+++ b/src/main/java/seedu/address/model/StateManager.java
@@ -26,6 +26,13 @@ public class StateManager {
     }
     
     /**
+     * On each new command, add a new command onto the undo stack to track its history
+     */
+    public void trackCommand(StateCommandPair newCommandPair){
+        this.undoStack.push(newCommandPair);
+    }
+    
+    /**
      * Undo the most recent command, then store that undo command in a redo stack
      */
     public void undo() {

--- a/src/main/java/seedu/address/model/StateManager.java
+++ b/src/main/java/seedu/address/model/StateManager.java
@@ -2,6 +2,8 @@
 package seedu.address.model;
 
 import java.util.Stack;
+
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.StateCommandPair;
 
 /**
@@ -36,8 +38,9 @@ public class StateManager {
 
     /**
      * Undo the most recent command, then store that undo command in a redo stack
+     * @throws CommandException 
      */
-    public void undo() {
+    public void undo() throws CommandException {
         if (undoStack.isEmpty()) {
             // Can't undo as no history
             System.out.println("No undo commands found");
@@ -46,14 +49,15 @@ public class StateManager {
             StateCommandPair currentCommand = undoStack.pop();
             redoStack.push(currentCommand);
             // Executing undo command
-            currentCommand.executeInvese();
+            currentCommand.executeInverseCommand();
         }
     }
     
     /**
      * Redo the most recently 'undo' command, then store that redo command in the undo stack
+     * @throws CommandException 
      */
-    public void redo() {
+    public void redo() throws CommandException {
         if (redoStack.isEmpty()) {
             // Can't redo as no history
             System.out.println("No redo commands found");
@@ -62,7 +66,7 @@ public class StateManager {
             StateCommandPair currentCommand = redoStack.pop();
             undoStack.push(currentCommand);
             // Executing redo command
-            currentCommand.execute();
+            currentCommand.executeCommand();
         }
     }
 }

--- a/src/main/java/seedu/address/model/StateManager.java
+++ b/src/main/java/seedu/address/model/StateManager.java
@@ -1,6 +1,7 @@
 package seedu.address.model;
 
 import java.util.Stack;
+import seedu.address.model.StateCommandPair;
 
 /**
  * Singleton class to handle Undo/Redo commands
@@ -8,13 +9,13 @@ import java.util.Stack;
 public class StateManager {
     
     private static StateManager instance = null;
-    private Stack<String> undoStack;
-    private Stack<String> redoStack;
+    private Stack<StateCommandPair> undoStack;
+    private Stack<StateCommandPair> redoStack;
     
     // Exists only to defeat instantiation.
     protected StateManager() {
-        undoStack = new Stack<String>();
-        redoStack = new Stack<String>();
+        undoStack = new Stack<StateCommandPair>();
+        redoStack = new Stack<StateCommandPair>();
     }
     // Returns the singleton instance
     public static StateManager getInstance() {
@@ -22,5 +23,37 @@ public class StateManager {
             instance = new StateManager();
         }
         return instance;
+    }
+    
+    /**
+     * Undo the most recent command, then store that undo command in a redo stack
+     */
+    public void undo() {
+        if (undoStack.isEmpty()) {
+            // Can't undo as no history
+            System.out.println("No undo commands found");
+        } else {
+            // Moving command from undo to redo
+            StateCommandPair currentCommand = undoStack.pop();
+            redoStack.push(currentCommand);
+            // Executing undo command
+            currentCommand.executeInvese();
+        }
+    }
+    
+    /**
+     * Redo the most recently 'undo' command, then store that redo command in the undo stack
+     */
+    public void redo() {
+        if (redoStack.isEmpty()) {
+            // Can't redo as no history
+            System.out.println("No redo commands found");
+        } else {
+            // Moving command from redo to undo
+            StateCommandPair currentCommand = redoStack.pop();
+            undoStack.push(currentCommand);
+            // Executing redo command
+            currentCommand.execute();
+        }
     }
 }

--- a/src/main/java/seedu/address/model/ToDoApp.java
+++ b/src/main/java/seedu/address/model/ToDoApp.java
@@ -87,7 +87,7 @@ public class ToDoApp implements ReadOnlyToDoApp {
         syncMasterTagListWith(p);
         tasks.add(p);
     }
-    
+
     /**
      * Adds a task to the address book at a specified index.
      * Also checks the new task's tags and updates {@link #tags} with any new tags found,

--- a/src/main/java/seedu/address/model/ToDoApp.java
+++ b/src/main/java/seedu/address/model/ToDoApp.java
@@ -87,6 +87,18 @@ public class ToDoApp implements ReadOnlyToDoApp {
         syncMasterTagListWith(p);
         tasks.add(p);
     }
+    
+    /**
+     * Adds a task to the address book at a specified index.
+     * Also checks the new task's tags and updates {@link #tags} with any new tags found,
+     * and updates the Tag objects in the task to point to those in {@link #tags}.
+     *
+     * @throws UniqueTaskList.DuplicateTaskException if an equivalent task already exists.
+     */
+    public void addTask(Task p, int idx) throws UniqueTaskList.DuplicateTaskException {
+        syncMasterTagListWith(p);
+        tasks.add(p, idx);
+    }
 
     /**
      * Updates the task in the list at position {@code index} with {@code editedReadOnlyTask}.

--- a/src/main/java/seedu/address/model/ToDoApp.java
+++ b/src/main/java/seedu/address/model/ToDoApp.java
@@ -88,6 +88,7 @@ public class ToDoApp implements ReadOnlyToDoApp {
         tasks.add(p);
     }
 
+    //@@author A0114395E
     /**
      * Adds a task to the address book at a specified index.
      * Also checks the new task's tags and updates {@link #tags} with any new tags found,
@@ -99,6 +100,7 @@ public class ToDoApp implements ReadOnlyToDoApp {
         syncMasterTagListWith(p);
         tasks.add(p, idx);
     }
+    //@@author
 
     /**
      * Updates the task in the list at position {@code index} with {@code editedReadOnlyTask}.

--- a/src/main/java/seedu/address/model/person/UniqueTaskList.java
+++ b/src/main/java/seedu/address/model/person/UniqueTaskList.java
@@ -41,6 +41,20 @@ public class UniqueTaskList implements Iterable<Task> {
         }
         internalList.add(toAdd);
     }
+    
+    //@@author A0114395E
+    /**
+     * Adds a task to the list in a specified index.
+     *
+     * @throws DuplicateTaskException if the task to add is a duplicate of an existing task in the list.
+     */
+    public void add(Task toAdd, int idx) throws DuplicateTaskException {
+        assert toAdd != null;
+        if (contains(toAdd)) {
+            throw new DuplicateTaskException();
+        }
+        internalList.add(idx, toAdd);
+    }
 
     /**
      * Updates the task in the list at position {@code index} with {@code editedTask}.

--- a/src/main/java/seedu/address/model/person/UniqueTaskList.java
+++ b/src/main/java/seedu/address/model/person/UniqueTaskList.java
@@ -41,7 +41,7 @@ public class UniqueTaskList implements Iterable<Task> {
         }
         internalList.add(toAdd);
     }
-    
+
     //@@author A0114395E
     /**
      * Adds a task to the list in a specified index.

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -1,3 +1,4 @@
+/* @@author A0114395E*/
 .background {
     -fx-background-color: derive(#309d67, 20.0%);
 }


### PR DESCRIPTION
## Can do _infinite_ undo/redo commands

#### Fixes #53 #57 #61 
---

### Supported undo/redo commands
1. Add
2. Delete
3. Edit

#### Undo 
`undo`
- Undo most recent command, up last edited command in the current session

#### Redo
`redo`
- Redo most recently `undo` command. 
- Redo history gets cleared whenever user enters a new command (that is not undo)